### PR TITLE
Avoid name collision on Julia nightly

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -128,7 +128,7 @@ let
 end
 
 # Load Pkg; circumvent user-modified LOAD_PATH
-const LOAD_PATH = copy(Base.LOAD_PATH)
+const ORIG_LOAD_PATH = copy(Base.LOAD_PATH)
 try
     push!(empty!(Base.LOAD_PATH), joinpath(Sys.STDLIB, "Pkg"))
     using Pkg
@@ -137,7 +137,7 @@ catch
     printstyled(stderr, "could not load Pkg.\n"; color=:red)
     rethrow()
 finally
-    append!(empty!(Base.LOAD_PATH), LOAD_PATH)
+    append!(empty!(Base.LOAD_PATH), ORIG_LOAD_PATH)
 end
 
 # Parse --update option


### PR DESCRIPTION
jlpkg fails on `julia-nightly` (1.5.0-DEV.360, Commit 012b270df6):

~~~~
$ jlpkg status
ERROR: LoadError: cannot assign a value to variable Base.LOAD_PATH from module Main
Stacktrace:
 [1] top-level scope at /home/felix/.local/bin/global/jlpkg:135
 [2] include(::Function, ::Module, ::String) at ./Base.jl:380
 [3] include(::Module, ::String) at ./Base.jl:368
 [4] exec_options(::Base.JLOptions) at ./client.jl:288
 [5] _start() at ./client.jl:490
in expression starting at /home/felix/.local/bin/global/jlpkg:135
~~~~

Looking at the changes since 1.4.0-rc2, it appears to be caused by https://github.com/JuliaLang/julia/commit/ef0e0f2923. This PR simply renames `LOAD_PATH` to `ORIG_LOAD_PATH` to avoid the name collision.