### PR TITLE
Avoid an error when `Base.have_color === nothing`

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -14,7 +14,6 @@ if !Sys.iswindows()
         cmd = Base.julia_cmd()
         cmd.exec[1] = julia # swap out the executable
         filter!(x -> !startswith(x, "-J"), cmd.exec) # filter out incompatible sysimg
-        push!(cmd.exec, "--color=$(Base.have_color ? "yes" : "no")")
         pipe = pipeline(`$(cmd) $(f) $(ARGS)`; stdout=stdout, stderr=stderr)
         try
             exit(!success(pipe))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,9 @@ mktempdir() do tmpdir; mktempdir() do depot
                 @test success(pipeline(`$(test_cmd) --julia=$(this_julia) --julia=$(julia11) --version`, stdout=stdout, stderr=stderr))
                 @test occursin(", julia version 1.1.1", read(stdout, String))
                 @test isempty(read(stderr, String))
+                @test success(pipeline(`$(test_cmd) --color=auto --julia=$(julia11) --version`, stdout=stdout, stderr=stderr))
+                @test occursin(", julia version 1.1.1", read(stdout, String))
+                @test isempty(read(stderr, String))
             end
         end
         # Smoke test all Pkg commands in interpreted mode


### PR DESCRIPTION
Since `Base.have_color` can be `nothing`,

https://github.com/fredrikekre/jlpkg/blob/3726a5e665c6c4ff02d110d0ca2a50d49fb3a3e0/src/cli.jl#L17

fails with

```console
$ jlpkg --julia=julia1.7 --version
ERROR: LoadError: TypeError: non-boolean (Nothing) used in boolean context
Stacktrace:
 [1] top-level scope
   @ ~/.julia/bin/jlpkg:26
in expression starting at /home/arakaki/.julia/bin/jlpkg:16
```

if `--color` is not given or `--color=auto` is used:

```console
$ julia -E 'Base.have_color'
nothing
$ julia --color=auto -E 'Base.have_color'
nothing
$ julia --color=yes -E 'Base.have_color'
true
$ julia --color=no -E 'Base.have_color'
false
```


Since the color flag is handled by `julia` itself for Julia 1.6 and later as of `jlpkg` 1.5.0 https://github.com/fredrikekre/jlpkg/commit/fb884b625eb08f6a95cc98aa2a396ac00514f801#diff-d2e1242ec6c61066777ffb9c3e75722fbbd5d86b75ce53366a648d9068104a17R11 maybe it is better to remove this manual propagation?
